### PR TITLE
Bump minimum core version to 2.176.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <revision>1.8</revision>
     <changelist>-SNAPSHOT</changelist>
-    <jenkins.version>2.138.4</jenkins.version>
+    <jenkins.version>2.176.3</jenkins.version>
     <java.level>8</java.level>
     <azure-credentials.version>2.0.1</azure-credentials.version>
     <jcasc.version>1.35</jcasc.version>


### PR DESCRIPTION
100% of users who upgraded to the previous version of the plugin are on this or higher,
98% of users who are on the version before this are on this or higher

http://stats.jenkins.io/pluginversions/azure-keyvault.html

Docs for when / why to upgrade:
https://jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/

While 2.150 is still supported as an LTS it is going out of support soon as a new LTS is coming out