### PR TITLE
Fix declarative example on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,12 +241,15 @@ Declarative Pipeline:
 
 ```groovy
 pipeline {
+    agent any
     environment {
         GITHUB_API_TOKEN = credentials('github-api-token')
     }
     stages {
         stage('Foo') {
-            echo '$GITHUB_API_TOKEN'
+            steps {
+                echo '$GITHUB_API_TOKEN'
+            }
         }
     }
 }


### PR DESCRIPTION
While writing the blog here: https://github.com/jenkins-infra/jenkins.io/pull/3004, I noticed that the declarative syntax is broken