### PR TITLE
JCasC - Don't throw an error if secret not found

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultEnvironmentExpander.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultEnvironmentExpander.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.azurekeyvaultplugin;
 import hudson.EnvVars;
 import java.io.IOException;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import org.jenkinsci.plugins.workflow.steps.EnvironmentExpander;
 
@@ -17,5 +18,11 @@ public class AzureKeyVaultEnvironmentExpander extends EnvironmentExpander {
     @Override
     public void expand(@Nonnull EnvVars env) throws IOException, InterruptedException {
         env.overrideAll(secrets);
+    }
+
+    @Nonnull
+    @Override
+    public Set<String> getSensitiveVariables() {
+        return secrets.keySet();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultSecretSource.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultSecretSource.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.azurekeyvaultplugin;
 
 import com.azure.core.credential.TokenCredential;
+import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
 import com.microsoft.azure.util.AzureCredentials;
@@ -32,12 +33,12 @@ public class AzureKeyVaultSecretSource extends SecretSource {
 
         SecretClient client = AzureCredentials.createKeyVaultClient(keyVaultCredentials, azureKeyVaultGlobalConfiguration.getKeyVaultURL());
 
-        KeyVaultSecret secretBundle = client.getSecret(secret);
-        if (secretBundle != null) {
+        try {
+            KeyVaultSecret secretBundle = client.getSecret(secret);
             return Optional.of(secretBundle.getValue());
+        } catch (ResourceNotFoundException ignored) {
+            LOGGER.info("Couldn't find secret: " + secret);
+            return Optional.empty();
         }
-
-        LOGGER.info("Couldn't find secret: " + secret);
-        return Optional.empty();
     }
 }


### PR DESCRIPTION
Regression from the track 1 -> track 2 sdk upgrade.
Should not throw errors when loading jcasc config as the user may not multiple secret sources