### PR TITLE
JENKINS-65091 Switch to caffeine caching

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,11 @@
       <version>182.v3ccd4a755864</version>
     </dependency>
 
+    <dependency>
+      <groupId>io.jenkins.plugins</groupId>
+      <artifactId>caffeine-api</artifactId>
+    </dependency>
+
     <!-- optional deps -->
     <dependency>
       <groupId>io.jenkins</groupId>

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultGlobalConfiguration.java
@@ -194,6 +194,23 @@ public class AzureKeyVaultGlobalConfiguration extends GlobalConfiguration {
     }
 
     @POST
+    public FormValidation doReloadCache() {
+        Jenkins.get().checkPermission(Jenkins.ADMINISTER);
+
+        if (keyVaultURL == null) {
+            return FormValidation.error("Key vault url is required");
+        }
+
+        if (credentialID == null) {
+            return FormValidation.error("Credential ID is required");
+        }
+
+        refresh();
+
+        return FormValidation.ok("Cache reloaded");
+    }
+
+    @POST
     @SuppressWarnings("unused")
     public FormValidation doTestConnection(
             @QueryParameter("keyVaultURL") final String keyVaultURL,

--- a/src/main/resources/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultGlobalConfiguration/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultGlobalConfiguration/config.jelly
@@ -7,8 +7,14 @@
         <f:entry title="Credential ID" field="credentialID">
             <c:select />
         </f:entry>
+
         <f:validateButton
             title="${%Test Connection}" progress="${%Testing...}"
             method="testConnection" with="keyVaultURL,credentialID" />
+
+        <f:validateButton
+                title="${%Reload cache}" progress="${%Testing...}"
+                method="reloadCache" />
+
     </f:section>
 </j:jelly>


### PR DESCRIPTION
We're seeing high thread contention in resolving the credential when using this with sonar.

The threads have changed a bit since sonar improvements were done but I'm seeing some serious thread issues that are hanging the UI.

See https://issues.jenkins.io/browse/JENKINS-65091

Caffeine provides a better API for what we need, stale data isn't really an issue here as new credentials don't normally appear often.

This implementation will:
* Invalidate cache after 2 hours
* Asynchronously reload cache every 10 minutes (after a read request comes in, but the read request will return immediately with the previous value)


As an aside I don't like that we have to maintain a complete view of all credentials =/, not so good in a cloud environment imo
 