### PR TITLE
Cache access tokens for secret clients

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
         <artifactId>bom-2.277.x</artifactId>
-        <version>924.vda78166e6655</version>
+        <version>950.v396cb834de1e</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -82,7 +82,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>azure-credentials</artifactId>
-      <version>182.v3ccd4a755864</version>
+      <version>190.v059127ae17bb</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultCredentialRetriever.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultCredentialRetriever.java
@@ -1,22 +1,16 @@
 package org.jenkinsci.plugins.azurekeyvaultplugin;
 
 import com.azure.core.credential.TokenCredential;
-import com.azure.identity.ClientSecretCredential;
 import com.azure.identity.ClientSecretCredentialBuilder;
 import com.azure.identity.ManagedIdentityCredentialBuilder;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
-import com.cloudbees.plugins.credentials.CredentialsMatchers;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
-import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
-import com.cloudbees.plugins.credentials.domains.DomainCredentials;
 import com.microsoft.azure.util.AzureBaseCredentials;
 import com.microsoft.azure.util.AzureCredentials;
 import com.microsoft.azure.util.AzureImdsCredentials;
 import hudson.model.Run;
 import io.jenkins.plugins.azuresdk.HttpClientRetriever;
-import java.util.Collections;
-import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
@@ -54,47 +48,6 @@ public class AzureKeyVaultCredentialRetriever {
                     " only 'Microsoft Azure Service Principal' and 'Managed Identities for Azure Resources' are supported");
         }
 
-        return credential;
-    }
-
-    public static TokenCredential getCredentialById(String credentialID) {
-        if (StringUtils.isEmpty(credentialID)) {
-            return null;
-        }
-        SystemCredentialsProvider systemCredentialsProvider = SystemCredentialsProvider.getInstance();
-        List<AzureImdsCredentials> azureImdsCredentials =
-                DomainCredentials.getCredentials(systemCredentialsProvider.getDomainCredentialsMap(),
-                        AzureImdsCredentials.class,
-                        Collections.emptyList(),
-                        CredentialsMatchers.withId(credentialID));
-
-        if (!azureImdsCredentials.isEmpty()) {
-            return new ManagedIdentityCredentialBuilder().build();
-        }
-
-        List<AzureCredentials> azureCredentials =
-                DomainCredentials.getCredentials(systemCredentialsProvider.getDomainCredentialsMap(),
-                        AzureCredentials.class,
-                        Collections.emptyList(),
-                        CredentialsMatchers.withId(credentialID));
-
-        ClientSecretCredential credential = null;
-        if (!azureCredentials.isEmpty()) {
-            LOGGER.log(Level.FINE, format("Fetched %s as AzureCredentials", credentialID));
-            AzureCredentials azureCredential = azureCredentials.get(0);
-
-            credential = new ClientSecretCredentialBuilder()
-                    .clientId(azureCredential.getClientId())
-                    .clientSecret(azureCredential.getPlainClientSecret())
-                    .httpClient(HttpClientRetriever.get())
-                    .tenantId(azureCredential.getTenant())
-                    .build();
-        }
-
-        if (credential == null) {
-            throw new AzureKeyVaultException(String.format("Credential: %s was not found for supported credentials " +
-                    "type.", credentialID));
-        }
         return credential;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultGlobalConfiguration.java
@@ -1,6 +1,5 @@
 package org.jenkinsci.plugins.azurekeyvaultplugin;
 
-import com.azure.core.credential.TokenCredential;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.cloudbees.plugins.credentials.Credentials;
 import com.cloudbees.plugins.credentials.CredentialsScope;
@@ -9,6 +8,7 @@ import com.cloudbees.plugins.credentials.common.IdCredentials;
 import com.microsoft.azure.util.AzureBaseCredentials;
 import com.microsoft.azure.util.AzureCredentials;
 import com.microsoft.azure.util.AzureImdsCredentials;
+import com.microsoft.jenkins.keyvault.SecretClientCache;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.model.Item;
@@ -227,9 +227,7 @@ public class AzureKeyVaultGlobalConfiguration extends GlobalConfiguration {
         }
 
         try {
-            TokenCredential keyVaultCredentials = AzureKeyVaultCredentialRetriever.getCredentialById(credentialID);
-
-            SecretClient client = AzureCredentials.createKeyVaultClient(keyVaultCredentials, keyVaultURL);
+            SecretClient client = SecretClientCache.get(credentialID, keyVaultURL);
 
             Long numberOfSecrets = client.listPropertiesOfSecrets().stream().count();
             return FormValidation.ok(String.format("Success, found %d secrets in the vault", numberOfSecrets));

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultSecretSource.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultSecretSource.java
@@ -5,6 +5,7 @@ import com.azure.core.exception.ResourceNotFoundException;
 import com.azure.security.keyvault.secrets.SecretClient;
 import com.azure.security.keyvault.secrets.models.KeyVaultSecret;
 import com.microsoft.azure.util.AzureCredentials;
+import com.microsoft.jenkins.keyvault.SecretClientCache;
 import hudson.Extension;
 import io.jenkins.plugins.casc.SecretSource;
 import java.util.Optional;
@@ -25,13 +26,13 @@ public class AzureKeyVaultSecretSource extends SecretSource {
         }
 
         String credentialID = azureKeyVaultGlobalConfiguration.getCredentialID();
-        TokenCredential keyVaultCredentials = AzureKeyVaultCredentialRetriever.getCredentialById(credentialID);
+        TokenCredential keyVaultCredentials = AzureCredentials.getSystemCredentialById(credentialID);
         if (keyVaultCredentials == null) {
             LOGGER.info("No AzureKeyVault credentials found, skipping jcasc secret resolution");
             return Optional.empty();
         }
 
-        SecretClient client = AzureCredentials.createKeyVaultClient(keyVaultCredentials, azureKeyVaultGlobalConfiguration.getKeyVaultURL());
+        SecretClient client = SecretClientCache.get(credentialID, azureKeyVaultGlobalConfiguration.getKeyVaultURL());
 
         try {
             KeyVaultSecret secretBundle = client.getSecret(secret);


### PR DESCRIPTION
Adds support for caching in:
* `CredentialProvider`
* Configuration as code integration

Does not add support in the pipeline wrappers as they have job context, a future PR could add support for it, they are already more efficient as they retrieve all requested secrets with one access token.

i.e. if you request 10 secrets in pipeline it will use the same access token, in the next step it will request a new one