### PR TITLE
Use one-column layout for credentials store

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsStore.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsStore.java
@@ -40,6 +40,12 @@ public class AzureCredentialsStore extends CredentialsStore {
                 && Jenkins.get().getACL().hasPermission(authentication, permission);
     }
 
+
+    //@Override
+    public String getLayoutType() {
+        return "one-column";
+    }
+
     @NonNull
     @Override
     public List<Credentials> getCredentials(@NonNull Domain domain) {


### PR DESCRIPTION
As the user can't add credentials directly in Jenkins to Azure it makes sense to use a single column layout so we don't have an empty sidepanel

requires https://github.com/jenkinsci/credentials-plugin/pull/364