### PR TITLE
Form validation now raises an error when KeyVaultURL or credentialID are empty

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultGlobalConfiguration.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureKeyVaultGlobalConfiguration.java
@@ -197,11 +197,11 @@ public class AzureKeyVaultGlobalConfiguration extends GlobalConfiguration {
     public FormValidation doReloadCache() {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
-        if (keyVaultURL == null) {
+        if (StringUtils.isBlank(keyVaultURL)) {
             return FormValidation.error("Key vault url is required");
         }
 
-        if (credentialID == null) {
+        if (StringUtils.isBlank(credentialID)) {
             return FormValidation.error("Credential ID is required");
         }
 
@@ -218,11 +218,11 @@ public class AzureKeyVaultGlobalConfiguration extends GlobalConfiguration {
     ) {
         Jenkins.get().checkPermission(Jenkins.ADMINISTER);
 
-        if (keyVaultURL == null) {
+        if (StringUtils.isBlank(keyVaultURL)) {
             return FormValidation.error("Key vault url is required");
         }
 
-        if (credentialID == null) {
+        if (StringUtils.isBlank(credentialID)) {
             return FormValidation.error("Credential ID is required");
         }
 


### PR DESCRIPTION

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

This PR intend to fix #125 
I have added checks to verify if KeyVaultURL or credentialID are blank. Before we were checking only for Null.

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
