### PR TITLE
Use Jenkins 2.361 LTS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,10 @@
-buildPlugin(useContainerAgent: true, platforms: ['linux'])
+/*
+ See the documentation for more options:
+ https://github.com/jenkins-infra/pipeline-library/
+*/
+buildPlugin(
+  useContainerAgent: true,
+  configurations: [
+    [platform: 'linux', jdk: 11],
+    [platform: 'linux', jdk: 17]
+])

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,8 @@
   </licenses>
 
   <scm>
-    <connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
-    <developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
+    <connection>scm:git:https://github.com/${gitHubRepo}</connection>
+    <developerConnection>scm:git:https://github.com/${gitHubRepo}</developerConnection>
     <url>https://github.com/${gitHubRepo}</url>
     <tag>${scmTag}</tag>
   </scm>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
   <properties>
     <changelist>9999-SNAPSHOT</changelist>
     <gitHubRepo>jenkinsci/azure-keyvault-plugin</gitHubRepo>
-    <jenkins.version>2.332.4</jenkins.version>
+    <jenkins.version>2.361.4</jenkins.version>
     <hpi.compatibleSinceVersion>2.0</hpi.compatibleSinceVersion>
   </properties>
 
@@ -54,7 +54,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.332.x</artifactId>
+        <artifactId>bom-2.361.x</artifactId>
         <version>1723.vcb_9fee52c9fc</version>
         <scope>import</scope>
         <type>pom</type>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.51</version>
+    <version>4.52</version>
     <relativePath />
   </parent>
   <artifactId>azure-keyvault</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
               <artifactId>checkstyle</artifactId>
-              <version>9.3</version>
+              <version>10.5.0</version>
             </dependency>
           </dependencies>
         </plugin>


### PR DESCRIPTION
Fixes https://github.com/jenkinsci/azure-keyvault-plugin/pull/138

Update to 2.361 LTS ([context](https://github.com/jenkinsci/plugin-pom/releases/tag/plugin-4.52)).