### PR TITLE
Azure kv ssh passphrase support

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ pipeline {
 
 #### SSH Username with private key and passphrase
 
-You should never directly set the passphrase as a tag in the Azure Key Vault.  However, some SSH Private Keys require such a passphrase.  To resolve this issue, first create a passphrase secret within your Azure Key Vault (This can be a generic secret, no tags are necessary).
+Some SSH private keys will require a passphrase to function as a credential.  Using the previous examples, it would make sense to provide a tag option for including the passphrase.  However, you should obviously never directly set the passphrase as a tag in the Azure Key Vault.  To resolve this issue, first create a passphrase secret within your Azure Key Vault (This can be a generic secret, no tags are necessary).
 
 ```bash
 az keyvault secret set \
@@ -371,7 +371,7 @@ az keyvault secret set --tags type=sshUserPrivateKey username=my-username passph
   -f ~/.ssh/my-ssh-key
 ```
 
-Creating the sshUserPrivateKey will query the AKV once again for the passphrase value.  If the Passphrase could not be found in the vault, the passphrase value will be defaulted to Null.
+Creating the sshUserPrivateKey will query the AKV once again for the passphrase value.  If the passphrase could not be found in the vault, the passphrase value will be defaulted to Null.
 
 #### Secret Labels
 

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
@@ -144,13 +144,17 @@ public class AzureCredentialsProvider extends CredentialsProvider {
                     }
                     case "sshUserPrivateKey": {
                         String usernameSecretTag = tags.get("username-is-secret");
+                        String passphraseID = tags.get("passphrase-id");
+                        Secret passphrase;
                         boolean usernameSecret = false;
                         if (StringUtils.isNotBlank(usernameSecretTag)) {
                             usernameSecret = Boolean.parseBoolean(usernameSecretTag);
                         }
-
+                        if (StringUtils.isNotBlank(passphraseID)) {
+                            passphrase = new KeyVaultSecretRetriever(client, passphraseID).get();
+                        }
                         AzureSSHUserPrivateKeyCredentials cred = new AzureSSHUserPrivateKeyCredentials(
-                                getSecretName(id), "", tags.get("username"), usernameSecret, new KeyVaultSecretRetriever(client, id)
+                                getSecretName(id), "", tags.get("username"), usernameSecret, passphrase, new KeyVaultSecretRetriever(client, id)
                         );
                         credentials.add(cred);
                         break;

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentials.java
@@ -21,17 +21,20 @@ public class AzureSSHUserPrivateKeyCredentials extends BaseStandardCredentials i
     private final String username;
     private final boolean usernameSecret;
     private final Supplier<Secret> value;
+    private final String passphrase;
 
     public AzureSSHUserPrivateKeyCredentials(
             String id,
             String description,
             String username,
             boolean usernameSecret,
+            String passphrase,
             Supplier<Secret> privateKey
     ) {
         super(id, description);
         this.username = username;
         this.usernameSecret = usernameSecret;
+        this.passphrase = passphrase;
         this.value = privateKey;
     }
 
@@ -47,9 +50,10 @@ public class AzureSSHUserPrivateKeyCredentials extends BaseStandardCredentials i
         return appendNewLineIfMissing(key);
     }
 
+    @NonNull
     @Override
     public Secret getPassphrase() {
-        return null;
+        return passphrase;
     }
 
     @NonNull

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentials.java
@@ -21,14 +21,14 @@ public class AzureSSHUserPrivateKeyCredentials extends BaseStandardCredentials i
     private final String username;
     private final boolean usernameSecret;
     private final Supplier<Secret> value;
-    private final String passphrase;
+    private final Secret passphrase;
 
     public AzureSSHUserPrivateKeyCredentials(
             String id,
             String description,
             String username,
             boolean usernameSecret,
-            String passphrase,
+            Secret passphrase,
             Supplier<Secret> privateKey
     ) {
         super(id, description);

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentialsSnapshotTaker.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentialsSnapshotTaker.java
@@ -21,6 +21,7 @@ public class AzureSSHUserPrivateKeyCredentialsSnapshotTaker extends CredentialsS
                 credential.getDescription(),
                 credential.getUsername(),
                 credential.isUsernameSecret(),
+                credentials.getPassphrase(),
                 secretSnapshot
         );
     }

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentialsSnapshotTaker.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentialsSnapshotTaker.java
@@ -21,7 +21,7 @@ public class AzureSSHUserPrivateKeyCredentialsSnapshotTaker extends CredentialsS
                 credential.getDescription(),
                 credential.getUsername(),
                 credential.isUsernameSecret(),
-                credentials.getPassphrase(),
+                credential.getPassphrase(),
                 secretSnapshot
         );
     }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Fixes https://github.com/jenkinsci/azure-keyvault-plugin/issues/170

Also includes a supplementary feature for secret filtering by labels

- [ X ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ X ] Ensure that the pull request title represents the desired changelog entry
- [ X ] Please describe what you did
- [ X ] Link to relevant issues in GitHub or Jira
- [ X ] Link to relevant pull requests, esp. upstream and downstream changes
- [ X ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

The changes have been tested with the following use cases:

**Connecting to an Azure Key Vault with two usernamePassword secrets and an SSH Key secret/No Passphrase**
Tested the code with no label Sys Prop or Env Var being set.  When Jenkins was loaded, I saw all the secrets in the Credentials page as set in the Key Vault.  When no passphrase tag is set, SSH key is still present with a null passphrase.

**Connecting to an Azure Key Vault with two usernamePassword secrets and an SSH Key secret/With valid passphrase-id tag**
All secrets loaded.  The passphrase ID references a valid secret in Azure Key Vault.  Once Jenkins starts up, the SSH key with the passphrase-id tag contains the passphrase secret from the vault.

**Connecting to an Azure Key Vault with two usernamePassword secrets and an SSH Key secret/With invalid passphrase-id tag**
All secrets loaded.  The passphrase ID references an **invalid** secret in Azure Key Vault.  Once Jenkins starts up, the SSH key cred with the invalid passphrase-id tag is still loaded with no errors, a warning log is printed in the console that the secret could not be resolved, and the passphrase for this SSH key cred was defaulted to Null.

**Connecting to an Azure Key Vault with two usernamePassword secrets/One with tag label=customLabel/No Env Vars or Sys Props set**
All Secrets loaded.

**Connecting to an Azure Key Vault with two usernamePassword secrets/One with tag label=customLabel/Env Vars or Sys Props set**
Only the secret containing `label=customLabel` set in AKV is loaded on Jenkins init. 