### PR TITLE
Allow Jenkins label selector tag to be a comma separated list

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
@@ -127,7 +127,8 @@ public class AzureCredentialsProvider extends CredentialsProvider {
 
                     if (StringUtils.isNotBlank(labelSelector)) {
                         String jenkinsLabels = tags.getOrDefault("jenkins-label", "");
-                        if (Arrays.asList(jenkinsLabels.split(",")).indexOf(labelSelector) == -1) {
+                        List<String> labelSelectors = Arrays.asList(jenkinsLabels.split(","));
+                        if (!labelSelectors.contains(labelSelector)) {
                             continue;
                         }
                     }

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
@@ -21,6 +21,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -124,9 +125,11 @@ public class AzureCredentialsProvider extends CredentialsProvider {
                         tags = new HashMap<>();
                     }
 
-                    if (StringUtils.isNotBlank(labelSelector) && !labelSelector.equals(tags.get("jenkins-label"))) {
-                        // User specified a label selector in config, but current credential does not contain a matching tag, skip iteration
-                        continue;
+                    if (StringUtils.isNotBlank(labelSelector)) {
+                        String jenkinsLabels = tags.getOrDefault("jenkins-label", "");
+                        if (Arrays.asList(jenkinsLabels.split(",")).indexOf(labelSelector) == -1) {
+                            continue;
+                        }
                     }
 
                     String type = tags.getOrDefault("type", DEFAULT_TYPE);


### PR DESCRIPTION
This change allows the **jenkins-label** tag in Azure to be a comma separated list instead of a single selector. 

This fixes https://github.com/jenkinsci/azure-keyvault-plugin/issues/182

### Testing done

This was tested in a live scenario.  Images show a comma separated list set as a tag in Azure and the credential showing up on the Jenkins server.

<img width="312" alt="Screenshot 2023-05-11 at 10 59 31 AM" src="https://github.com/jenkinsci/azure-keyvault-plugin/assets/2847606/92e431ab-85a2-4222-81aa-0a89afd4a8e3">

<img width="772" alt="Screenshot 2023-05-11 at 11 00 27 AM" src="https://github.com/jenkinsci/azure-keyvault-plugin/assets/2847606/989aca55-8b1b-42b8-ab25-78614b75657a">

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
