### PR TITLE
Add 'jenkinsID' and 'description' to available Azure tags

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
@@ -134,6 +134,8 @@ public class AzureCredentialsProvider extends CredentialsProvider {
                     }
 
                     String type = tags.getOrDefault("type", DEFAULT_TYPE);
+                    String jenkinsID = tags.getOrDefault("jenkinsID", getSecretName(id));
+                    String description = tags.getOrDefault("description", "");
 
                     // initial implementation didn't require a type
                     if (tags.containsKey("username") && type.equals(DEFAULT_TYPE)) {
@@ -142,13 +144,13 @@ public class AzureCredentialsProvider extends CredentialsProvider {
 
                     switch (type) {
                         case "string": {
-                            AzureSecretStringCredentials cred = new AzureSecretStringCredentials(getSecretName(id), "", new KeyVaultSecretRetriever(client, id));
+                            AzureSecretStringCredentials cred = new AzureSecretStringCredentials(jenkinsID, description, new KeyVaultSecretRetriever(client, id));
                             credentials.add(cred);
                             break;
                         }
                         case "username": {
                             AzureUsernamePasswordCredentials cred = new AzureUsernamePasswordCredentials(
-                                    getSecretName(id), tags.get("username"), "", new KeyVaultSecretRetriever(client, id)
+                                    jenkinsID, tags.get("username"), description, new KeyVaultSecretRetriever(client, id)
                             );
                             credentials.add(cred);
                             break;
@@ -171,7 +173,7 @@ public class AzureCredentialsProvider extends CredentialsProvider {
 
                             }
                             AzureSSHUserPrivateKeyCredentials cred = new AzureSSHUserPrivateKeyCredentials(
-                                    getSecretName(id), "", tags.get("username"), usernameSecret, passphrase, new KeyVaultSecretRetriever(client, id)
+                                    jenkinsID, description, tags.get("username"), usernameSecret, passphrase, new KeyVaultSecretRetriever(client, id)
                             );
                             credentials.add(cred);
                             break;


### PR DESCRIPTION
This PR adds two tags to those available in Azure: **jenkinsID** and **description**.  **jenkinsID** will be used as the _ID_ in Jenkins instead of the Azure ID in order to separate the two and remove the restrictions placed on the Azure ID.  **description** will populate the _Name_ field in the Jenkins credential.

### Testing done
Production testing to verify the values are populated on a Jenkins server.   See the below images from the Azure Portal and Jenkins.

<img width="338" alt="Screenshot 2023-05-31 at 2 44 59 PM" src="https://github.com/jenkinsci/azure-keyvault-plugin/assets/2847606/340bf20a-1e26-4f90-be9a-aecd3955012d">

<img width="753" alt="Screenshot 2023-05-31 at 2 40 33 PM" src="https://github.com/jenkinsci/azure-keyvault-plugin/assets/2847606/32764bc1-8a01-446d-9658-bf160d7c4fb2">

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
