### PR TITLE
Add support for scoping credentials to SYSTEM

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,15 +422,15 @@ az keyvault secret set --vault-name my-vault \
 
 With the System Property or Environment variable being set in this example, only the usernamePassword `testUserWithLabel` will be present in your Jenkins instance.
 
-#### Jenkins Credential ID and Description
+#### Jenkins Credential ID, Description and Scope
 
-The ID and description of credentials can be specified with tags on the Azure Key Vault secret. The ID is specified with the tag "jenkinsID" and appears in the Jenkins credentials UI in the "ID" column. This is the credentials ID parameter used in `withCredentials()` calls. The description is specified with the tag "description" and appears in Jenkins credentials UI in the "Name" column.
+The ID, description and scope of credentials can be specified with tags on the Azure Key Vault secret. The ID is specified with the tag "jenkinsID" and appears in the Jenkins credentials UI in the "ID" column. This is the credentials ID parameter used in `withCredentials()` calls. The description is specified with the tag "description" and appears in the Jenkins credentials UI in the "Name" column. The scope is specified with the tag "scope" and can be set to "system" or "global". By default the scope will be set to global.
 
 ```bash
 az keyvault secret set --vault-name my-vault \
   --name testUserWithLabel \
   --value example2 \
-  --tags jenkinsID=myCred description="This is my credential"
+  --tags jenkinsID=myCred description="This is my credential" scope=system
 ```
 
 ### SecretSource

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentials.java
@@ -3,6 +3,7 @@ package org.jenkinsci.plugins.azurekeyvaultplugin.credentials.sshuserprivatekey;
 import com.cloudbees.jenkins.plugins.sshcredentials.SSHUserPrivateKey;
 import com.cloudbees.jenkins.plugins.sshcredentials.impl.Messages;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -24,6 +25,7 @@ public class AzureSSHUserPrivateKeyCredentials extends BaseStandardCredentials i
     private final Secret passphrase;
 
     public AzureSSHUserPrivateKeyCredentials(
+            CredentialsScope scope,
             String id,
             String description,
             String username,
@@ -31,7 +33,7 @@ public class AzureSSHUserPrivateKeyCredentials extends BaseStandardCredentials i
             Secret passphrase,
             Supplier<Secret> privateKey
     ) {
-        super(id, description);
+        super(scope, id, description);
         this.username = username;
         this.usernameSecret = usernameSecret;
         this.passphrase = passphrase;

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentialsSnapshotTaker.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/sshuserprivatekey/AzureSSHUserPrivateKeyCredentialsSnapshotTaker.java
@@ -17,6 +17,7 @@ public class AzureSSHUserPrivateKeyCredentialsSnapshotTaker extends CredentialsS
     public AzureSSHUserPrivateKeyCredentials snapshot(AzureSSHUserPrivateKeyCredentials credential) {
         SecretSnapshot secretSnapshot = new SecretSnapshot(credential.getSecretValue());
         return new AzureSSHUserPrivateKeyCredentials(
+                credential.getScope(),
                 credential.getId(),
                 credential.getDescription(),
                 credential.getUsername(),

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/string/AzureSecretStringCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/string/AzureSecretStringCredentials.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.azurekeyvaultplugin.credentials.string;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
@@ -15,8 +16,8 @@ public class AzureSecretStringCredentials extends BaseStandardCredentials implem
 
     private final Supplier<Secret> value;
 
-    public AzureSecretStringCredentials(String id, String description, Supplier<Secret> value) {
-        super(id, description);
+    public AzureSecretStringCredentials(CredentialsScope scope, String id, String description, Supplier<Secret> value) {
+        super(scope, id, description);
         this.value = value;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/string/AzureSecretStringCredentialsSnapshotTaker.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/string/AzureSecretStringCredentialsSnapshotTaker.java
@@ -16,7 +16,7 @@ public class AzureSecretStringCredentialsSnapshotTaker extends CredentialsSnapsh
     @Override
     public AzureSecretStringCredentials snapshot(AzureSecretStringCredentials credential) {
         SecretSnapshot secretSnapshot = new SecretSnapshot(credential.getSecret());
-        return new AzureSecretStringCredentials(credential.getId(), credential.getDescription(), secretSnapshot);
+        return new AzureSecretStringCredentials(credential.getScope(), credential.getId(), credential.getDescription(), secretSnapshot);
     }
 
     private static class SecretSnapshot extends Snapshot<Secret> {

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/usernamepassword/AzureUsernamePasswordCredentials.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/usernamepassword/AzureUsernamePasswordCredentials.java
@@ -1,6 +1,7 @@
 package org.jenkinsci.plugins.azurekeyvaultplugin.credentials.usernamepassword;
 
 import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsScope;
 import com.cloudbees.plugins.credentials.common.StandardUsernamePasswordCredentials;
 import com.cloudbees.plugins.credentials.impl.BaseStandardCredentials;
 import com.cloudbees.plugins.credentials.impl.Messages;
@@ -18,12 +19,13 @@ public class AzureUsernamePasswordCredentials extends BaseStandardCredentials im
     private final String username;
 
     public AzureUsernamePasswordCredentials(
+            CredentialsScope scope,
             String id,
             String username,
             String description,
             Supplier<Secret> password
     ) {
-        super(id, description);
+        super(scope, id, description);
         this.password = password;
         this.username = Util.fixNull(username);
     }

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/usernamepassword/AzureUsernamePasswordCredentialsSnapshotTaker.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/usernamepassword/AzureUsernamePasswordCredentialsSnapshotTaker.java
@@ -16,7 +16,7 @@ public class AzureUsernamePasswordCredentialsSnapshotTaker extends CredentialsSn
     @Override
     public AzureUsernamePasswordCredentials snapshot(AzureUsernamePasswordCredentials credential) {
         SecretSnapshot secretSnapshot = new SecretSnapshot(credential.getPassword());
-        return new AzureUsernamePasswordCredentials(credential.getId(), credential.getUsername(), credential.getDescription(), secretSnapshot);
+        return new AzureUsernamePasswordCredentials(credential.getScope(), credential.getId(), credential.getUsername(), credential.getDescription(), secretSnapshot);
     }
 
     private static class SecretSnapshot extends Snapshot<Secret> {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This change adds support for scoping Jenkins credentials to system. For the secret in Key Vault to be scoped to system in Jenkins, a tag of 'scope' should be set on the Key Vault secret with a value of 'system'. If no scope is set on the Key Vault secret, the default scope will be global. The code uses the same logic as the Kubernetes Credentials Provider plugin to scope the credential to system.

This partially meets #199 although it doesn't include scoping credentials to items (e.g. jobs/ folders).

### Testing done
This was tested manually with the following steps.

1. Secrets created in Azure Key Vault with the following tags

**Secret Text**
![image](https://github.com/jenkinsci/azure-keyvault-plugin/assets/85300277/855bfd50-ba53-4782-bc76-8ca4b1317e6c)

**SSH Private Key**
![image](https://github.com/jenkinsci/azure-keyvault-plugin/assets/85300277/80b80106-c07f-4788-934d-5420f973a0f7)

**Username/Password**
![image](https://github.com/jenkinsci/azure-keyvault-plugin/assets/85300277/50e2935c-8fcc-43ed-a7db-3ceabb032148)

3. Azure Key Vault plugin configured in Jenkins to pull in the credentials
![image](https://github.com/jenkinsci/azure-keyvault-plugin/assets/85300277/967d573b-adea-410c-ae4f-5aa78bf9d6fa)

4. Credentials are accessible for system settings

**Secret Text**
![image](https://github.com/jenkinsci/azure-keyvault-plugin/assets/85300277/4a3248c5-9320-4cd3-b00e-0637a63cb0d2)

**SSH Private Key & Username/Password**
![image](https://github.com/jenkinsci/azure-keyvault-plugin/assets/85300277/c8a5ac7d-783e-4249-8101-1bbdc5a617ad)

5. Credentials aren't accessible for jobs

**Secret Text**
![image](https://github.com/jenkinsci/azure-keyvault-plugin/assets/85300277/5294b3b9-eaa5-4c65-b6a2-e0f7b67138a0)

**SSH Private Key**
![image](https://github.com/jenkinsci/azure-keyvault-plugin/assets/85300277/0f24a90e-59ad-4d26-97b1-c0db195d7a54)

**Username/Password**
![image](https://github.com/jenkinsci/azure-keyvault-plugin/assets/85300277/f9f6c6d2-f615-4fbd-bfa5-d21993620ee7)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
