### PR TITLE
Add trailing slash if it doesn't exist

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
@@ -140,6 +140,13 @@ public class AzureCredentialsProvider extends CredentialsProvider {
             if (StringUtils.isEmpty(keyVaultURL) || StringUtils.isEmpty(credentialID)) {
                 return Collections.emptyList();
             }
+
+            // If keyVaultURL does not have a trailing slash, add one
+            if (!String.valueOf(keyVaultURL.charAt(keyVaultURL.length() -1)).equals("/")) {
+                LOG.log(Level.FINE, "Adding trailing slash to key vault URL");
+                keyVaultURL = keyVaultURL + "/";
+            }
+
             SecretClient client = SecretClientCache.get(credentialID, keyVaultURL);
 
             String labelSelector = extractLabelSelector();

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
@@ -142,9 +142,8 @@ public class AzureCredentialsProvider extends CredentialsProvider {
             }
 
             // If keyVaultURL does not have a trailing slash, add one
-            if (!String.valueOf(keyVaultURL.charAt(keyVaultURL.length() -1)).equals("/")) {
-                LOG.log(Level.FINE, "Adding trailing slash to key vault URL");
-                keyVaultURL = keyVaultURL + "/";
+            if (!keyVaultURL.endsWith("/")) {
+                keyVaultURL += "/";
             }
 
             SecretClient client = SecretClientCache.get(credentialID, keyVaultURL);


### PR DESCRIPTION
This PR adds a trailing slash to the Key Vault URL if it does not already exist. This is to fix #227 where the passphrase for SSH keys wasn't being retrieved if the URL did not contain the trailing slash.

Fixes #227

### Testing done

If the Key Vault URL is missing the trailing slash, the passphrase for the SSH key is still retrieved successfully and the SSH key is created in Jenkins.
![image](https://github.com/jenkinsci/azure-keyvault-plugin/assets/85300277/03905164-caf2-4ecf-9fae-72b23961259d)

![image](https://github.com/jenkinsci/azure-keyvault-plugin/assets/85300277/7fceac6a-4b5e-478c-85c3-6fd91fc716fa)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
