### PR TITLE
Add Support of comma separated labels into Azure KeyVault Label Selector variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,6 +482,7 @@ To filter out secrets from being set, add a System Property or Environment Varia
 ```
 
 **Via Environment Variable**:
+
 ```bash
 AZURE_KEYVAULT_LABEL_SELECTOR=myCustomLabel
 ```
@@ -503,6 +504,10 @@ az keyvault secret set --vault-name my-vault \
 ```
 
 Multiple label selectors can be specified as a comma separated list:
+
+```bash
+AZURE_KEYVAULT_LABEL_SELECTOR=myCustomLabel,anotherCustomLabel
+```
 
 ```bash
 az keyvault secret set --vault-name my-vault \

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
@@ -150,7 +150,7 @@ public class AzureCredentialsProvider extends CredentialsProvider {
 
             SecretClient client = SecretClientCache.get(credentialID, keyVaultURL);
 
-            String labelSelector = extractLabelSelector();
+            String configuredLabelSelector = extractLabelSelector();
             List<IdCredentials> credentials = new ArrayList<>();
             for (SecretProperties secretItem : client.listPropertiesOfSecrets()) {
                 String id = secretItem.getId();
@@ -160,11 +160,11 @@ public class AzureCredentialsProvider extends CredentialsProvider {
                     if (tags == null) {
                         tags = new HashMap<>();
                     }
-
-                    if (StringUtils.isNotBlank(labelSelector)) {
-                        String jenkinsLabels = tags.getOrDefault("jenkins-label", "");
-                        List<String> labelSelectors = Arrays.asList(jenkinsLabels.split(","));
-                        if (!labelSelectors.contains(labelSelector)) {
+                    if (StringUtils.isNotBlank(configuredLabelSelector)) {
+                        String secretLabelSelector = tags.getOrDefault("jenkins-label", "");
+                        List<String> secretLabels = Arrays.asList(secretLabelSelector.split(","));
+                        List<String> configuredLabels = Arrays.asList(configuredLabelSelector.split(","));
+                        if (secretLabels.stream().filter(configuredLabels::contains).findAny().isEmpty()) {
                             continue;
                         }
                     }
@@ -176,7 +176,7 @@ public class AzureCredentialsProvider extends CredentialsProvider {
 
                     CredentialsScope scope = CredentialsScope.GLOBAL;
 
-                    if (tags.containsKey("scope") && labelScope.equals("SYSTEM")) {
+                    if (tags.containsKey("scope") && labelScope.equalsIgnoreCase("SYSTEM")) {
                         scope = CredentialsScope.SYSTEM;
                     }
 


### PR DESCRIPTION

Hello,

in the objective of distributing multiple secrets to multiple Jenkins instances without having to duplicate the common ones, let's allow as well a label list into AZURE_KEYVAULT_LABEL_SELECTOR variable so that we take the secret only if at least one label is matching.

### Testing done

In the vault, I created multiple secrets, one with label 'default', one with label 'default,dev2-ops', one with label 'dev1-ops' and one with no labels.
First, as Jenkins env var I set: AZURE_KEYVAULT_LABEL_SELECTOR=default,dev2-ops.
after starting Jenkins I can see only the 'default' or 'dev2-ops' labeled secrets are taking.
Then, as Jenkins env var I set: AZURE_KEYVAULT_LABEL_SELECTOR=default,dev1-ops.
restarting Jenkins i can see I have now the secrets that have 'default' or 'dev2-ops' label.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
