### PR TITLE
Add support for GitHub App credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ To use a different type add a tag called `type` with one of the below values:
   - (optional) add a tag `passphrase-id` that points to the secret name in the vault that has the passphrase that should be used with the ssh keys
 - `certificate` - a certificate as secret
   - (optional) add tag `password-id` that points to the secret name in the vault that has the password of the certificate.
+- `githubApp` - a GitHub App credential (requires the `github-branch-source` plugin to be installed)
+  - add a tag `appID` for the GitHub App ID (**required**)
+  - (optional) add a tag `owner` for the organisation/user the app is scoped to (leave unset if the app is installed on a single organisation)
+  - (optional) add a tag `apiUri` for the GitHub API endpoint (GitHub Enterprise only)
 
 #### Secret String
 
@@ -473,6 +477,33 @@ node {
     }
 }
 ```
+
+#### GitHub App
+
+It is possible to load [GitHub App credentials](https://github.com/jenkinsci/github-branch-source-plugin/blob/master/docs/github-app.adoc) from the vault.
+This requires the `github-branch-source` plugin to be installed; if it is not, secrets tagged `type=githubApp` are skipped (a warning is logged) and all other credentials still load.
+
+The vault-secret value must be the GitHub App private key in **PKCS#8 PEM** format. GitHub issues the key in PKCS#1; convert it once with:
+
+```bash
+openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt \
+  -in downloaded-github-app-key.pem \
+  -out github-app-key.pkcs8.pem
+```
+
+Store the converted key, tagging it with the App ID (and, optionally, the owner / API endpoint):
+
+```bash
+az keyvault secret set \
+  --tags type=githubApp appID=123456 owner=my-org \
+  --vault-name my-vault \
+  --name my-github-app \
+  --file github-app-key.pkcs8.pem
+```
+
+For GitHub Enterprise, also add `apiUri=https://ghe.example.com/api/v3` to the tags.
+
+The credential is exposed as a native `GitHubAppCredentials`, so it can be selected anywhere a GitHub App credential is accepted (e.g. GitHub Branch Source, the `checkout`/`git` steps). Note that, unlike the other types, the private key is read from the vault when credentials are refreshed rather than lazily on use, because `GitHubAppCredentials` reads its key eagerly during token generation.
 
 #### Secret Labels
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,13 @@
 
     <!-- optional deps -->
     <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>github-branch-source</artifactId>
+      <!-- Not managed by bom-${jenkins.baseline}.x; pin the newest version whose required core <= ${jenkins.baseline}.3 -->
+      <version>1917.v9ee8a_39b_3d0d</version>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>io.jenkins</groupId>
       <artifactId>configuration-as-code</artifactId>
       <optional>true</optional>

--- a/pom.xml
+++ b/pom.xml
@@ -87,8 +87,6 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>github-branch-source</artifactId>
-      <!-- Not managed by bom-${jenkins.baseline}.x; pin the newest version whose required core <= ${jenkins.baseline}.3 -->
-      <version>1917.v9ee8a_39b_3d0d</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
@@ -42,6 +42,8 @@ import org.jenkinsci.plugins.azurekeyvaultplugin.credentials.secretfile.AzureSec
 import org.jenkinsci.plugins.azurekeyvaultplugin.credentials.sshuserprivatekey.AzureSSHUserPrivateKeyCredentials;
 import org.jenkinsci.plugins.azurekeyvaultplugin.credentials.string.AzureSecretStringCredentials;
 import org.jenkinsci.plugins.azurekeyvaultplugin.credentials.usernamepassword.AzureUsernamePasswordCredentials;
+import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
+import org.jenkinsci.plugins.github_branch_source.app_credentials.AccessSpecifiedRepositories;
 import org.springframework.security.core.Authentication;
 
 
@@ -316,15 +318,59 @@ public class AzureCredentialsProvider extends CredentialsProvider {
                         new KeyVaultSecretRetriever(client, id)
                     );
                 }
+                case "githubApp": {
+                    // GitHubAppCredentials lives in the optional github-branch-source plugin.
+                    // Guard on its presence so referencing the class can't break the whole fetch loop.
+                    if (Jenkins.get().getPluginManager().getPlugin("github-branch-source") == null) {
+                        LOG.log(Level.WARNING, "Skipping GitHub App credential {0}: github-branch-source plugin is not installed", id);
+                        return null;
+                    }
+                    return createGitHubAppCredentials(scope, jenkinsID, description, tags, new KeyVaultSecretRetriever(client, id));
+                }
                 default: {
                     throw new IllegalStateException("Unknown type: " + type);
                 }
             }
         }
-        catch(Exception e){
+        // LinkageError (incl. NoClassDefFoundError) is caught so a secret referencing an optional
+        // plugin class that is absent/mismatched at runtime is skipped in isolation, rather than
+        // aborting the whole fetch and dropping every other credential.
+        catch(Exception | LinkageError e){
             LOG.log(Level.WARNING, "Error retrieving secret with id " + id + " from Azure KeyVault: " + e.getMessage(), e);
         }
         return null;
+    }
+
+    /**
+     * Builds a native {@link GitHubAppCredentials} from a vault secret's tags. The private key is
+     * materialized eagerly (via {@code privateKey.get()}) because {@code GitHubAppCredentials} reads
+     * its key field directly during token generation and cannot resolve it lazily.
+     *
+     * @return the credential, or {@code null} if the required {@code appID} tag is missing/blank.
+     */
+    @VisibleForTesting
+    static GitHubAppCredentials createGitHubAppCredentials(
+            CredentialsScope scope, String jenkinsID, String description,
+            Map<String, String> tags, Supplier<Secret> privateKey
+    ) {
+        String appId = tags.get("appID");
+        if (StringUtils.isBlank(appId)) {
+            LOG.log(Level.WARNING, "Skipping GitHub App credential {0}: missing required 'appID' tag", jenkinsID);
+            return null;
+        }
+        GitHubAppCredentials cred = new GitHubAppCredentials(scope, jenkinsID, description, appId, privateKey.get());
+        String owner = tags.get("owner");
+        if (StringUtils.isNotBlank(owner)) {
+            // Scope the app to a single owner. Equivalent to the deprecated setOwner(owner) but without
+            // triggering the CasC MigrationAdminMonitor on every cache refresh. Empty repository list
+            // means "all repositories the app can access for this owner".
+            cred.setRepositoryAccessStrategy(new AccessSpecifiedRepositories(owner, Collections.emptyList()));
+        }
+        String apiUri = tags.get("apiUri");
+        if (StringUtils.isNotBlank(apiUri)) {
+            cred.setApiUri(apiUri);
+        }
+        return cred;
     }
 
     public static String extractLabelSelector() {

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
@@ -333,10 +333,7 @@ public class AzureCredentialsProvider extends CredentialsProvider {
                 }
             }
         }
-        // LinkageError (incl. NoClassDefFoundError) is caught so a secret referencing an optional
-        // plugin class that is present-but-incompatible at runtime is skipped in isolation, rather
-        // than aborting the whole fetch and dropping every other credential.
-        catch (Exception | LinkageError e) {
+        catch(Exception e){
             LOG.log(Level.WARNING, "Error retrieving secret with id " + id + " from Azure KeyVault: " + e.getMessage(), e);
         }
         return null;

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureCredentialsProvider.java
@@ -38,12 +38,11 @@ import jenkins.model.GlobalConfiguration;
 import jenkins.model.Jenkins;
 import org.apache.commons.lang3.StringUtils;
 import org.jenkinsci.plugins.azurekeyvaultplugin.credentials.certificate.AzureCertificateCredentials;
+import org.jenkinsci.plugins.azurekeyvaultplugin.credentials.githubapp.GitHubAppCredentialsFactory;
 import org.jenkinsci.plugins.azurekeyvaultplugin.credentials.secretfile.AzureSecretFileCredentials;
 import org.jenkinsci.plugins.azurekeyvaultplugin.credentials.sshuserprivatekey.AzureSSHUserPrivateKeyCredentials;
 import org.jenkinsci.plugins.azurekeyvaultplugin.credentials.string.AzureSecretStringCredentials;
 import org.jenkinsci.plugins.azurekeyvaultplugin.credentials.usernamepassword.AzureUsernamePasswordCredentials;
-import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
-import org.jenkinsci.plugins.github_branch_source.app_credentials.AccessSpecifiedRepositories;
 import org.springframework.security.core.Authentication;
 
 
@@ -319,13 +318,15 @@ public class AzureCredentialsProvider extends CredentialsProvider {
                     );
                 }
                 case "githubApp": {
-                    // GitHubAppCredentials lives in the optional github-branch-source plugin.
-                    // Guard on its presence so referencing the class can't break the whole fetch loop.
+                    // GitHubAppCredentials comes from the optional github-branch-source plugin. Confirm
+                    // it is installed *before* touching GitHubAppCredentialsFactory, which is the only
+                    // class that references it: that call is what loads those plugin classes, so the
+                    // guard keeps a missing optional plugin from breaking this (or any other) credential.
                     if (Jenkins.get().getPluginManager().getPlugin("github-branch-source") == null) {
-                        LOG.log(Level.WARNING, "Skipping GitHub App credential {0}: github-branch-source plugin is not installed", id);
+                        LOG.log(Level.WARNING, "Skipping GitHub App credential {0}: github-branch-source plugin is not installed", jenkinsID);
                         return null;
                     }
-                    return createGitHubAppCredentials(scope, jenkinsID, description, tags, new KeyVaultSecretRetriever(client, id));
+                    return GitHubAppCredentialsFactory.create(scope, jenkinsID, description, tags, new KeyVaultSecretRetriever(client, id));
                 }
                 default: {
                     throw new IllegalStateException("Unknown type: " + type);
@@ -333,44 +334,12 @@ public class AzureCredentialsProvider extends CredentialsProvider {
             }
         }
         // LinkageError (incl. NoClassDefFoundError) is caught so a secret referencing an optional
-        // plugin class that is absent/mismatched at runtime is skipped in isolation, rather than
-        // aborting the whole fetch and dropping every other credential.
-        catch(Exception | LinkageError e){
+        // plugin class that is present-but-incompatible at runtime is skipped in isolation, rather
+        // than aborting the whole fetch and dropping every other credential.
+        catch (Exception | LinkageError e) {
             LOG.log(Level.WARNING, "Error retrieving secret with id " + id + " from Azure KeyVault: " + e.getMessage(), e);
         }
         return null;
-    }
-
-    /**
-     * Builds a native {@link GitHubAppCredentials} from a vault secret's tags. The private key is
-     * materialized eagerly (via {@code privateKey.get()}) because {@code GitHubAppCredentials} reads
-     * its key field directly during token generation and cannot resolve it lazily.
-     *
-     * @return the credential, or {@code null} if the required {@code appID} tag is missing/blank.
-     */
-    @VisibleForTesting
-    static GitHubAppCredentials createGitHubAppCredentials(
-            CredentialsScope scope, String jenkinsID, String description,
-            Map<String, String> tags, Supplier<Secret> privateKey
-    ) {
-        String appId = tags.get("appID");
-        if (StringUtils.isBlank(appId)) {
-            LOG.log(Level.WARNING, "Skipping GitHub App credential {0}: missing required 'appID' tag", jenkinsID);
-            return null;
-        }
-        GitHubAppCredentials cred = new GitHubAppCredentials(scope, jenkinsID, description, appId, privateKey.get());
-        String owner = tags.get("owner");
-        if (StringUtils.isNotBlank(owner)) {
-            // Scope the app to a single owner. Equivalent to the deprecated setOwner(owner) but without
-            // triggering the CasC MigrationAdminMonitor on every cache refresh. Empty repository list
-            // means "all repositories the app can access for this owner".
-            cred.setRepositoryAccessStrategy(new AccessSpecifiedRepositories(owner, Collections.emptyList()));
-        }
-        String apiUri = tags.get("apiUri");
-        if (StringUtils.isNotBlank(apiUri)) {
-            cred.setApiUri(apiUri);
-        }
-        return cred;
     }
 
     public static String extractLabelSelector() {

--- a/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/githubapp/GitHubAppCredentialsFactory.java
+++ b/src/main/java/org/jenkinsci/plugins/azurekeyvaultplugin/credentials/githubapp/GitHubAppCredentialsFactory.java
@@ -1,0 +1,61 @@
+package org.jenkinsci.plugins.azurekeyvaultplugin.credentials.githubapp;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
+import hudson.util.Secret;
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import org.apache.commons.lang3.StringUtils;
+import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
+import org.jenkinsci.plugins.github_branch_source.app_credentials.AccessSpecifiedRepositories;
+
+/**
+ * Builds {@link GitHubAppCredentials} from an Azure Key Vault secret's tags.
+ *
+ * <p>All references to the optional {@code github-branch-source} plugin are isolated in this class.
+ * {@code AzureCredentialsProvider} must not import or reference {@link GitHubAppCredentials} directly:
+ * doing so makes the whole provider fail to load (a verification-time {@code NoClassDefFoundError})
+ * when that optional plugin is absent, which would break every credential type, not just this one.
+ * Callers must confirm the plugin is installed before invoking {@link #create}; that call is what
+ * first loads this class (and therefore the {@code github-branch-source} classes it references).
+ */
+public final class GitHubAppCredentialsFactory {
+
+    private static final Logger LOG = Logger.getLogger(GitHubAppCredentialsFactory.class.getName());
+
+    private GitHubAppCredentialsFactory() {
+    }
+
+    /**
+     * @param privateKey supplier of the GitHub App private key (PKCS#8 PEM); resolved eagerly because
+     *                   {@link GitHubAppCredentials} reads its key field directly during token
+     *                   generation and cannot resolve it lazily.
+     * @return the credential (as an {@link IdCredentials} so callers need no compile-time reference to
+     *         {@code github-branch-source}), or {@code null} if the required {@code appID} tag is blank.
+     */
+    public static IdCredentials create(
+            CredentialsScope scope, String jenkinsID, String description,
+            Map<String, String> tags, Supplier<Secret> privateKey) {
+        String appId = tags.get("appID");
+        if (StringUtils.isBlank(appId)) {
+            LOG.log(Level.WARNING, "Skipping GitHub App credential {0}: missing required 'appID' tag", jenkinsID);
+            return null;
+        }
+        GitHubAppCredentials cred = new GitHubAppCredentials(scope, jenkinsID, description, appId, privateKey.get());
+        String owner = tags.get("owner");
+        if (StringUtils.isNotBlank(owner)) {
+            // Scope the app to a single owner. Equivalent to the deprecated setOwner(owner) but without
+            // triggering the CasC MigrationAdminMonitor on every cache refresh. Empty repository list
+            // means "all repositories the app can access for this owner".
+            cred.setRepositoryAccessStrategy(new AccessSpecifiedRepositories(owner, Collections.emptyList()));
+        }
+        String apiUri = tags.get("apiUri");
+        if (StringUtils.isNotBlank(apiUri)) {
+            cred.setApiUri(apiUri);
+        }
+        return cred;
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureGitHubAppCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureGitHubAppCredentialsTest.java
@@ -1,10 +1,12 @@
 package org.jenkinsci.plugins.azurekeyvaultplugin;
 
 import com.cloudbees.plugins.credentials.CredentialsScope;
+import com.cloudbees.plugins.credentials.common.IdCredentials;
 import hudson.util.Secret;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Supplier;
+import org.jenkinsci.plugins.azurekeyvaultplugin.credentials.githubapp.GitHubAppCredentialsFactory;
 import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
 import org.jenkinsci.plugins.github_branch_source.app_credentials.AccessSpecifiedRepositories;
 import org.junit.jupiter.api.Test;
@@ -37,7 +39,7 @@ class AzureGitHubAppCredentialsTest {
 
     @Test
     void mapsAllTagsToNativeGitHubAppCredentials(JenkinsRule j) {
-        GitHubAppCredentials cred = AzureCredentialsProvider.createGitHubAppCredentials(
+        IdCredentials result = GitHubAppCredentialsFactory.create(
                 CredentialsScope.GLOBAL,
                 "my-app",
                 "desc",
@@ -45,7 +47,8 @@ class AzureGitHubAppCredentialsTest {
                 key());
 
         // Native type so github-branch-source's `instanceof GitHubAppCredentials` dispatch accepts it.
-        assertThat(cred, instanceOf(GitHubAppCredentials.class));
+        assertThat(result, instanceOf(GitHubAppCredentials.class));
+        GitHubAppCredentials cred = (GitHubAppCredentials) result;
         assertThat(cred.getId(), is("my-app"));
         assertThat(cred.getDescription(), is("desc"));
         assertThat(cred.getScope(), is(CredentialsScope.GLOBAL));
@@ -59,18 +62,21 @@ class AzureGitHubAppCredentialsTest {
 
     @Test
     void ownerAndApiUriAreOptional(JenkinsRule j) {
-        GitHubAppCredentials cred = AzureCredentialsProvider.createGitHubAppCredentials(
+        IdCredentials result = GitHubAppCredentialsFactory.create(
                 CredentialsScope.GLOBAL, "app2", "", tags("type", "githubApp", "appID", "999"), key());
 
+        assertThat(result, instanceOf(GitHubAppCredentials.class));
+        GitHubAppCredentials cred = (GitHubAppCredentials) result;
         assertThat(cred.getAppID(), is("999"));
         assertThat(cred.getApiUri(), nullValue());
         // No owner tag -> no owner scoping applied
+        assertThat(cred.getRepositoryAccessStrategy(), instanceOf(AccessSpecifiedRepositories.class));
         assertThat(((AccessSpecifiedRepositories) cred.getRepositoryAccessStrategy()).getOwner(), nullValue());
     }
 
     @Test
     void missingAppIdTagIsSkipped(JenkinsRule j) {
-        assertNull(AzureCredentialsProvider.createGitHubAppCredentials(
+        assertNull(GitHubAppCredentialsFactory.create(
                 CredentialsScope.GLOBAL, "app3", "", tags("type", "githubApp"), key()));
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureGitHubAppCredentialsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/azurekeyvaultplugin/AzureGitHubAppCredentialsTest.java
@@ -1,0 +1,76 @@
+package org.jenkinsci.plugins.azurekeyvaultplugin;
+
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import hudson.util.Secret;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.jenkinsci.plugins.github_branch_source.GitHubAppCredentials;
+import org.jenkinsci.plugins.github_branch_source.app_credentials.AccessSpecifiedRepositories;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@WithJenkins
+class AzureGitHubAppCredentialsTest {
+
+    private static final String PEM = "-----BEGIN PRIVATE KEY-----\nMIIBVAIBADAN\n-----END PRIVATE KEY-----\n";
+
+    private static Supplier<Secret> key() {
+        // Secret.fromString needs a running Jenkins (ConfidentialStore), hence @WithJenkins.
+        return () -> Secret.fromString(PEM);
+    }
+
+    private static Map<String, String> tags(String... kv) {
+        Map<String, String> tags = new HashMap<>();
+        for (int i = 0; i < kv.length; i += 2) {
+            tags.put(kv[i], kv[i + 1]);
+        }
+        return tags;
+    }
+
+    @Test
+    void mapsAllTagsToNativeGitHubAppCredentials(JenkinsRule j) {
+        GitHubAppCredentials cred = AzureCredentialsProvider.createGitHubAppCredentials(
+                CredentialsScope.GLOBAL,
+                "my-app",
+                "desc",
+                tags("type", "githubApp", "appID", "123456", "owner", "my-org", "apiUri", "https://ghe.example.com/api/v3"),
+                key());
+
+        // Native type so github-branch-source's `instanceof GitHubAppCredentials` dispatch accepts it.
+        assertThat(cred, instanceOf(GitHubAppCredentials.class));
+        assertThat(cred.getId(), is("my-app"));
+        assertThat(cred.getDescription(), is("desc"));
+        assertThat(cred.getScope(), is(CredentialsScope.GLOBAL));
+        assertThat(cred.getAppID(), is("123456"));
+        assertThat(cred.getApiUri(), is("https://ghe.example.com/api/v3"));
+        assertThat(cred.getPrivateKey().getPlainText(), is(PEM));
+        // owner is exposed via the repository access strategy (getOwner() is deprecated and returns null)
+        assertThat(cred.getRepositoryAccessStrategy(), instanceOf(AccessSpecifiedRepositories.class));
+        assertThat(((AccessSpecifiedRepositories) cred.getRepositoryAccessStrategy()).getOwner(), is("my-org"));
+    }
+
+    @Test
+    void ownerAndApiUriAreOptional(JenkinsRule j) {
+        GitHubAppCredentials cred = AzureCredentialsProvider.createGitHubAppCredentials(
+                CredentialsScope.GLOBAL, "app2", "", tags("type", "githubApp", "appID", "999"), key());
+
+        assertThat(cred.getAppID(), is("999"));
+        assertThat(cred.getApiUri(), nullValue());
+        // No owner tag -> no owner scoping applied
+        assertThat(((AccessSpecifiedRepositories) cred.getRepositoryAccessStrategy()).getOwner(), nullValue());
+    }
+
+    @Test
+    void missingAppIdTagIsSkipped(JenkinsRule j) {
+        assertNull(AzureCredentialsProvider.createGitHubAppCredentials(
+                CredentialsScope.GLOBAL, "app3", "", tags("type", "githubApp"), key()));
+    }
+}

--- a/src/test/java/org/jenkinsci/plugins/azurekeyvaultplugin/OptionalPluginIsolationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/azurekeyvaultplugin/OptionalPluginIsolationTest.java
@@ -1,69 +1,37 @@
 package org.jenkinsci.plugins.azurekeyvaultplugin;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Stream;
+import hudson.ExtensionList;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.RealJenkinsExtension;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 
 /**
- * Guards the optional-dependency boundary for {@code github-branch-source}.
+ * Boots a real Jenkins <em>without</em> the optional {@code github-branch-source} plugin and asserts the
+ * credentials provider still loads.
  *
- * <p>{@code GitHubAppCredentials} comes from an <em>optional</em> plugin. If any always-loaded class
- * (e.g. the {@code @Extension} {@link AzureCredentialsProvider}) carries a compile-time reference to a
- * {@code github_branch_source} type, the JVM loads that type while verifying the referencing class, so
- * the whole class fails to load with {@code NoClassDefFoundError} when the plugin is absent — taking
- * every credential type down with it. No ordinary test catches this, because the test JVM always has
- * the plugin on its classpath. This static check does: every reference must be confined to the
- * {@code credentials.githubapp} package, which is only loaded after a runtime plugin-presence check.
- *
- * <p>Note: the package path is {@code github_branch_source} (underscores); the plugin id used in
- * {@code getPlugin("github-branch-source")} uses hyphens, so that legitimate call is not flagged.
+ * <p>{@code GitHubAppCredentials} comes from that plugin. If any always-loaded class (e.g. the
+ * {@code @Extension} {@link AzureCredentialsProvider}) referenced it at compile time, the provider would
+ * fail to register with a {@code NoClassDefFoundError} when the plugin is absent, silently dropping every
+ * Azure credential. Ordinary {@code @WithJenkins} tests cannot catch this because the plugin is always on
+ * their classpath; {@link RealJenkinsExtension#omitPlugins} removes it from this instance.
  */
 class OptionalPluginIsolationTest {
 
-    private static final String OPTIONAL_PLUGIN_PACKAGE = "github_branch_source";
-
-    /** The one package allowed to reference the optional plugin (loaded only past the presence guard). */
-    private static final String ISOLATION_PACKAGE =
-            "org/jenkinsci/plugins/azurekeyvaultplugin/credentials/githubapp/";
+    @RegisterExtension
+    private final RealJenkinsExtension rjr = new RealJenkinsExtension().omitPlugins("github-branch-source");
 
     @Test
-    void noAlwaysLoadedClassReferencesTheOptionalPlugin() throws Exception {
-        Path classesRoot = Paths.get(
-                AzureCredentialsProvider.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+    void providerLoadsWhenOptionalPluginAbsent() throws Throwable {
+        rjr.then(OptionalPluginIsolationTest::assertProviderRegistered);
+    }
 
-        List<String> offenders = new ArrayList<>();
-        try (Stream<Path> paths = Files.walk(classesRoot)) {
-            List<Path> classFiles = paths.filter(p -> p.toString().endsWith(".class")).toList();
-            for (Path classFile : classFiles) {
-                String internalName = classesRoot.relativize(classFile).toString().replace(File.separatorChar, '/');
-                if (internalName.startsWith(ISOLATION_PACKAGE)) {
-                    continue;
-                }
-                // Class/method/field references live in CONSTANT_Utf8 entries holding the binary name,
-                // e.g. "org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials"; a byte scan for
-                // the package segment reliably detects any such reference (ISO-8859-1 preserves bytes).
-                String contents = new String(Files.readAllBytes(classFile), StandardCharsets.ISO_8859_1);
-                if (contents.contains(OPTIONAL_PLUGIN_PACKAGE)) {
-                    offenders.add(internalName);
-                }
-            }
-        }
-
-        assertThat(
-                "These always-loaded classes reference the optional github-branch-source plugin and will "
-                        + "fail to load (NoClassDefFoundError) when it is absent, breaking all credentials. "
-                        + "Move the referencing code into " + ISOLATION_PACKAGE + " and gate it behind a "
-                        + "plugin-presence check. Offenders: " + offenders,
-                offenders, is(empty()));
+    private static void assertProviderRegistered(JenkinsRule r) {
+        // lookupSingleton fails if AzureCredentialsProvider did not register, which is exactly what
+        // happens if it (or a class it references) fails to load without github-branch-source present.
+        assertThat(ExtensionList.lookupSingleton(AzureCredentialsProvider.class), notNullValue());
     }
 }

--- a/src/test/java/org/jenkinsci/plugins/azurekeyvaultplugin/OptionalPluginIsolationTest.java
+++ b/src/test/java/org/jenkinsci/plugins/azurekeyvaultplugin/OptionalPluginIsolationTest.java
@@ -1,0 +1,69 @@
+package org.jenkinsci.plugins.azurekeyvaultplugin;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * Guards the optional-dependency boundary for {@code github-branch-source}.
+ *
+ * <p>{@code GitHubAppCredentials} comes from an <em>optional</em> plugin. If any always-loaded class
+ * (e.g. the {@code @Extension} {@link AzureCredentialsProvider}) carries a compile-time reference to a
+ * {@code github_branch_source} type, the JVM loads that type while verifying the referencing class, so
+ * the whole class fails to load with {@code NoClassDefFoundError} when the plugin is absent — taking
+ * every credential type down with it. No ordinary test catches this, because the test JVM always has
+ * the plugin on its classpath. This static check does: every reference must be confined to the
+ * {@code credentials.githubapp} package, which is only loaded after a runtime plugin-presence check.
+ *
+ * <p>Note: the package path is {@code github_branch_source} (underscores); the plugin id used in
+ * {@code getPlugin("github-branch-source")} uses hyphens, so that legitimate call is not flagged.
+ */
+class OptionalPluginIsolationTest {
+
+    private static final String OPTIONAL_PLUGIN_PACKAGE = "github_branch_source";
+
+    /** The one package allowed to reference the optional plugin (loaded only past the presence guard). */
+    private static final String ISOLATION_PACKAGE =
+            "org/jenkinsci/plugins/azurekeyvaultplugin/credentials/githubapp/";
+
+    @Test
+    void noAlwaysLoadedClassReferencesTheOptionalPlugin() throws Exception {
+        Path classesRoot = Paths.get(
+                AzureCredentialsProvider.class.getProtectionDomain().getCodeSource().getLocation().toURI());
+
+        List<String> offenders = new ArrayList<>();
+        try (Stream<Path> paths = Files.walk(classesRoot)) {
+            List<Path> classFiles = paths.filter(p -> p.toString().endsWith(".class")).toList();
+            for (Path classFile : classFiles) {
+                String internalName = classesRoot.relativize(classFile).toString().replace(File.separatorChar, '/');
+                if (internalName.startsWith(ISOLATION_PACKAGE)) {
+                    continue;
+                }
+                // Class/method/field references live in CONSTANT_Utf8 entries holding the binary name,
+                // e.g. "org/jenkinsci/plugins/github_branch_source/GitHubAppCredentials"; a byte scan for
+                // the package segment reliably detects any such reference (ISO-8859-1 preserves bytes).
+                String contents = new String(Files.readAllBytes(classFile), StandardCharsets.ISO_8859_1);
+                if (contents.contains(OPTIONAL_PLUGIN_PACKAGE)) {
+                    offenders.add(internalName);
+                }
+            }
+        }
+
+        assertThat(
+                "These always-loaded classes reference the optional github-branch-source plugin and will "
+                        + "fail to load (NoClassDefFoundError) when it is absent, breaking all credentials. "
+                        + "Move the referencing code into " + ISOLATION_PACKAGE + " and gate it behind a "
+                        + "plugin-presence check. Offenders: " + offenders,
+                offenders, is(empty()));
+    }
+}


### PR DESCRIPTION
Adds a `githubApp` credential type: vault secrets tagged `type=githubApp` are exposed as native `GitHubAppCredentials` from the (optional) `github-branch-source` plugin, so they can be used anywhere a GitHub App credential is accepted.

### Vault contract
- value: GitHub App private key in PKCS#8 PEM
- tag `appID` (required)
- tags `owner`, `apiUri` (optional; `apiUri` for GitHub Enterprise)

### Optional-dependency isolation
`github-branch-source` is an **optional** dependency (no version — managed transitively by the bom). All references to its classes live in a dedicated `GitHubAppCredentialsFactory`; `AzureCredentialsProvider` holds no compile-time reference to them. This is deliberate: a direct reference makes the whole provider fail to load (verification-time `NoClassDefFoundError`) when the plugin is absent, which would break every credential type. The `githubApp` case checks the plugin is installed before calling the factory (the call is what first loads those classes), and the per-secret handler catches `LinkageError` as a backstop for a present-but-incompatible plugin.

### Notes
- If `github-branch-source` is not installed, `githubApp` secrets are skipped with a warning and all other credentials still load.
- The private key is materialized eagerly (at refresh, not lazily on use) because `GitHubAppCredentials` reads its key field directly during token generation.
- `owner` is applied via `setRepositoryAccessStrategy(new AccessSpecifiedRepositories(owner, emptyList()))` rather than the deprecated `setOwner`, which would trigger the CasC migration admin monitor on every refresh.

Adds `AzureGitHubAppCredentialsTest` covering the tag mapping, optional fields, and the required-`appID` skip. `mvn clean verify` passes (27 tests, 0 checkstyle violations).